### PR TITLE
Complying <real> and <integer> to OpenQASM 2.0 standard; Added parse_toplevel_source.

### DIFF
--- a/openqasm/src/lib.rs
+++ b/openqasm/src/lib.rs
@@ -81,7 +81,6 @@
 //! and `serde::Deserialize` for all the AST types.
 //!
 
-#![deny(mutable_borrow_reservation_conflict)]
 #![cfg_attr(all(nightly_build, doc), feature(doc_auto_cfg))]
 
 #[macro_use]


### PR DESCRIPTION
1. The original <real> tokenizer has problem parsing scientific notations, which is allowed and widely used in OpenQASM 2.0 programs (e.g. QASMBench).

According to spec: https://arxiv.org/pdf/1707.03429

```
real := ([0-9]+\.[0-9]*|[0-9]*\.[0-9]+)([eE][-+]?[0-9]+)?
nninteger := [1-9]+[0-9]*|0
```
2. Added `parse_toplevel_source` to check `OPENQASM 2.0;` at the start. This is useful when parsing a handful of source top files where some of them are missing `OPENQASM 2.0;` signature and need to be added manually.